### PR TITLE
Add possibility to press TAB to queue items for bulk download

### DIFF
--- a/src/app/components/List.tsx
+++ b/src/app/components/List.tsx
@@ -105,7 +105,23 @@ const List = (props: Props) => {
         }
       }
 
-      if (renderList[Math.floor(renderList.length / 3)].expandable && key.return) {
+      const selectedItem: Item | undefined = renderList[Math.floor(renderList.length / 3)];
+
+      if (key.tab) {
+        if (selectedItem?.data?.id) {
+          const itemChecked: boolean = bulkQueue.indexOf(selectedItem.data.id) > -1;
+          handleOnSelect(
+            expanded,
+            setExpanded,
+            selectedItem.data,
+            itemChecked
+              ? returnedValue.removeFromBulkDownloadingQueue
+              : returnedValue.addToBulkDownloadingQueue
+          );
+        }
+      }
+
+      if (selectedItem.expandable && key.return) {
         setExpanded(!expanded);
       }
     }


### PR DESCRIPTION
I was looking for a fast way to add/remove search results to the bulk download queue without having to expand each item and select the "Add To Bulk Downloading Queue" option individually. So I added this.