### PR TITLE
Add "Select All" Feature to Interactive Mode

### DIFF
--- a/src/labels.ts
+++ b/src/labels.ts
@@ -3,6 +3,7 @@ export default {
   NEXT_PAGE: "→ Next Page",
   PREV_PAGE: "← Prev Page",
   START_BULK_DOWNLOAD: "@ Start Bulk Download",
+  SELECT_ALL: "* Select All Results",
   EXIT: "✖ Exit",
   SEE_DETAILS: "See Details",
   ALTERNATIVE_DOWNLOADS: "Alternative Downloads",

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,6 +11,7 @@ export enum Option {
   REMOVE_FROM_BULK_DOWNLOAD_QUEUE = "remove_from_bulk_download_queue_option",
   TURN_BACK_TO_THE_LIST = "turn_back_to_the_list_option",
   BACK_TO_ENTRY_OPTIONS = "back_to_entry_options",
+  SELECT_ALL = "select_all_option",
 }
 
 export enum ResultListEntryOption {

--- a/src/tui/store/app.ts
+++ b/src/tui/store/app.ts
@@ -117,6 +117,9 @@ export const createAppStateSlice = (
   setDetailedEntry: (detailedEntry: Entry | null) => set({ detailedEntry }),
   setEntries: (entries: Entry[]) => {
     const store = get();
+    const allSelected = entries.every((entry) =>
+      get().bulkDownloadSelectedEntryIds.includes(entry.id)
+    );
     const listItems = constructListItems({
       entries,
       currentPage: store.currentPage,
@@ -130,13 +133,26 @@ export const createAppStateSlice = (
           store.setActiveLayout(LAYOUT_KEY.DOWNLOAD_QUEUE_BEFORE_EXIT_LAYOUT);
           return;
         }
-
         if (get().bulkDownloadSelectedEntryIds.length > 0) {
           store.setActiveLayout(LAYOUT_KEY.BULK_DOWNLOAD_BEFORE_EXIT_LAYOUT);
           return;
         }
-
         store.handleExit();
+      },
+      handleSelectAllOption: () => {
+        const addToBulkDownloadQueue = get().addToBulkDownloadQueue;
+        const removeFromBulkDownloadQueue = get().removeFromBulkDownloadQueue;
+        if (
+          entries.every((entry) =>
+            get().bulkDownloadSelectedEntryIds.includes(entry.id)
+          )
+        ) {
+          // Deselect all
+          entries.forEach((entry) => removeFromBulkDownloadQueue(entry.id));
+        } else {
+          // Select all
+          entries.forEach((entry) => addToBulkDownloadQueue(entry));
+        }
       },
     });
     set({ entries, listItems });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,8 @@ export const constructListItems = ({
   handlePrevPageOption,
   handleStartBulkDownloadOption,
   handleExitOption,
-}: constructInitialListItemsArgs) => {
+  handleSelectAllOption,
+}: constructInitialListItemsArgs & { handleSelectAllOption: () => void }) => {
   const entryListItems: ListItem[] = entries.map<ListItem>((entry, idx) => ({
     type: IResultListItemType.Entry,
     data: entry,
@@ -90,6 +91,8 @@ export const constructListItems = ({
     ),
 
     createOptionItem(Option.SEARCH, Label.SEARCH, handleSearchOption),
+
+    createOptionItem(Option.SELECT_ALL, Label.SELECT_ALL, handleSelectAllOption),
 
     ...(isNextPageAvailable
       ? [createOptionItem(Option.NEXT_PAGE, Label.NEXT_PAGE, handleNextPageOption)]


### PR DESCRIPTION
Summary
This PR introduces a "Select All" option in the interactive (TUI) mode. Users can now add all current search results to the bulk download queue with a single action, instead of selecting each result manually.

Changes
CLI/TUI
Added a new option in the search results list: Select All Results.
When selected, all current search results are added to the bulk download queue.
Codebase
Updated constructListItems utility to include the "Select All" option.
Added Option.SELECT_ALL and Label.SELECT_ALL for consistent labeling.
Wired up a handler in the store to add all entries to the bulk download queue when "Select All" is chosen.
Motivation
Previously, users had to manually select each search result to add it to the download queue. This new feature streamlines the process, especially for bulk downloads, improving user experience and efficiency.

Testing
Ran the TUI, performed a search, and verified that selecting "Select All Results" adds all visible results to the bulk download queue.
Confirmed that the feature does not interfere with other navigation or selection options.

![Screenshot 2025-06-14 235135](https://github.com/user-attachments/assets/b7d08934-69f5-41be-a186-a502250db084)
![Screenshot 2025-06-14 235111](https://github.com/user-attachments/assets/259d711b-888f-42a5-9e9d-b89bc0a63ec7)
