### PR TITLE
Fix Node downloads and add core test coverage

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,48 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pull-request-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Typecheck, test, lint, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Check formatting
+        run: bun run format:check
+
+      - name: Build and smoke-test Node.js bundle
+        run: |
+          bun run build
+          node build/index.js --help

--- a/bun.lock
+++ b/bun.lock
@@ -20,12 +20,13 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/bun": "^1.3.14",
         "@types/content-disposition": "^0.5.9",
+        "@types/node": "^26.1.1",
         "@types/object-hash": "3.0.6",
         "@types/react": "^19.2.7",
         "@typescript-eslint/eslint-plugin": "^8.52.0",
         "@typescript-eslint/parser": "^8.52.0",
-        "bun-types": "^1.3.5",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
@@ -120,13 +121,15 @@
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@1.1.2", "", { "dependencies": { "defer-to-connect": "^1.0.1" } }, "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/content-disposition": ["@types/content-disposition@0.5.9", "", {}, "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@12.19.4", "", {}, "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="],
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/object-hash": ["@types/object-hash@3.0.6", "", {}, "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w=="],
 
@@ -208,7 +211,7 @@
 
     "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
 
-    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cacheable-request": ["cacheable-request@6.1.0", "", { "dependencies": { "clone-response": "^1.0.2", "get-stream": "^5.1.0", "http-cache-semantics": "^4.0.0", "keyv": "^3.0.0", "lowercase-keys": "^2.0.0", "normalize-url": "^4.1.0", "responselike": "^1.0.2" } }, "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg=="],
 
@@ -888,6 +891,8 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "unique-string": ["unique-string@1.0.0", "", { "dependencies": { "crypto-random-string": "^1.0.0" } }, "sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
@@ -975,6 +980,8 @@
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "electron/@types/node": ["@types/node@12.19.4", "", {}, "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="],
 
     "eslint/@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default defineConfig([
     },
     rules: {
       "linebreak-style": ["error", "unix"],
-      quotes: ["error", "double"],
+      quotes: ["error", "double", { avoidEscape: true }],
       semi: ["error", "always"],
       "no-ternary": "error",
       "react/no-multi-comp": "error",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "homepage": "https://github.com/obsfx/libgen-downloader",
   "scripts": {
     "start": "bun run src/index.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
     "build": "bun build src/index.ts --outdir ./build --target node && echo '#!/usr/bin/env node' | cat - ./build/index.js > ./build/temp && mv ./build/temp ./build/index.js",
     "compile": "bun run clean && bun run compile:linux-x64 && bun run compile:linux-arm64 && bun run compile:macos-x64 && bun run compile:macos-arm64 && bun run compile:windows-x64",
     "compile:linux-x64": "bun build src/index.ts --compile --target=bun-linux-x64 --outfile ./standalone-executables/libgen-downloader-linux-x64",
@@ -17,9 +19,10 @@
     "compile:macos-x64": "bun build src/index.ts --compile --target=bun-darwin-x64 --outfile ./standalone-executables/libgen-downloader-macos-x64",
     "compile:macos-arm64": "bun build src/index.ts --compile --target=bun-darwin-arm64 --outfile ./standalone-executables/libgen-downloader-macos-arm64",
     "compile:windows-x64": "bun build src/index.ts --compile --target=bun-windows-x64 --outfile ./standalone-executables/libgen-downloader-windows-x64.exe",
-    "lint": "eslint 'src/**/*.{js,jsx,ts,tsx,json}'",
-    "lint:fix": "eslint --fix 'src/**/*.{js,jsx,ts,tsx,json}'",
-    "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc",
+    "lint": "eslint 'src/**/*.{js,jsx,ts,tsx,json}' 'test/**/*.ts'",
+    "lint:fix": "eslint --fix 'src/**/*.{js,jsx,ts,tsx,json}' 'test/**/*.ts'",
+    "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md,json}' 'test/**/*.ts' --config ./.prettierrc",
+    "format:check": "prettier --check 'src/**/*.{js,jsx,ts,tsx,css,md,json}' 'test/**/*.ts' --config ./.prettierrc",
     "clean": "rimraf ./build && rimraf ./standalone-executables"
   },
   "keywords": [
@@ -43,12 +46,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/bun": "^1.3.14",
     "@types/content-disposition": "^0.5.9",
+    "@types/node": "^26.1.1",
     "@types/object-hash": "3.0.6",
     "@types/react": "^19.2.7",
     "@typescript-eslint/eslint-plugin": "^8.52.0",
     "@typescript-eslint/parser": "^8.52.0",
-    "bun-types": "^1.3.5",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",

--- a/src/api/adapters/libgen-plus-adapter.ts
+++ b/src/api/adapters/libgen-plus-adapter.ts
@@ -29,7 +29,6 @@ export class LibgenPlusAdapter implements Adapter {
     const entryElements = containerTable.children;
 
     for (const element of entryElements) {
-
       const id = nanoid();
       const authors = clearText(element.children[1]?.textContent || "")
         .split(";")

--- a/src/api/data/download.ts
+++ b/src/api/data/download.ts
@@ -1,7 +1,8 @@
 import contentDisposition from "content-disposition";
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import fs from "fs";
-import { DownloadResult } from "../models/download-result";
+import fs from "node:fs";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { DownloadResult } from "../models/download-result";
 
 interface downloadFileArguments {
   downloadStream: Response;
@@ -37,25 +38,20 @@ export const downloadFile = async ({
 
   onStart(filename, total);
 
-  const file = fs.createWriteStream(path);
-  const reader = downloadStream.body.getReader();
+  const progressStream = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      const buffer = Buffer.from(chunk);
+      onData(filename, buffer, total);
+      callback(undefined, buffer);
+    },
+  });
 
   try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      const chunk = Buffer.from(value);
-      file.write(chunk);
-      onData(filename, chunk, total);
-    }
-
-    file.end();
-
-    await new Promise<void>((resolve, reject) => {
-      file.on("finish", resolve);
-      file.on("error", reject);
-    });
+    await pipeline(
+      Readable.from(downloadStream.body, { objectMode: false }),
+      progressStream,
+      fs.createWriteStream(path)
+    );
 
     const downloadResult: DownloadResult = {
       path,
@@ -65,7 +61,6 @@ export const downloadFile = async ({
 
     return downloadResult;
   } catch {
-    file.destroy();
     throw new Error(`(${filename}) Error occurred while downloading file`);
   }
 };

--- a/src/cli/operate.ts
+++ b/src/cli/operate.ts
@@ -60,7 +60,9 @@ export const operate = async (flags: Record<string, unknown>) => {
       return;
     }
 
-    const downloadUrl = store.mirrorAdapter?.getMainDownloadURLFromDocument(detailPageResult.document);
+    const downloadUrl = store.mirrorAdapter?.getMainDownloadURLFromDocument(
+      detailPageResult.document
+    );
     if (!downloadUrl) {
       console.log("Failed to find download url");
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { cli } from "./cli";
 import { operate } from "./cli/operate";
 
-
 operate(cli.flags);
 
-export {version as APP_VERSION} from "../package.json";
+export { version as APP_VERSION } from "../package.json";

--- a/src/tui/components/error-message.tsx
+++ b/src/tui/components/error-message.tsx
@@ -25,14 +25,14 @@ export function ErrorMessage() {
       <OptionList
         options={{
           ...(canRetry && {
-                [ErrorMessageOption.RETRY]: {
-                  label: Label.RETRY,
-                  onSelect: () => {
-                    setErrorMessage(undefined);
-                    handleSearchSubmit();
-                  },
-                },
-              }),
+            [ErrorMessageOption.RETRY]: {
+              label: Label.RETRY,
+              onSelect: () => {
+                setErrorMessage(undefined);
+                handleSearchSubmit();
+              },
+            },
+          }),
           [ErrorMessageOption.EXIT]: {
             label: Label.EXIT,
             onSelect: () => handleExit(),

--- a/src/tui/components/mirror-failover.tsx
+++ b/src/tui/components/mirror-failover.tsx
@@ -15,7 +15,7 @@ const MirrorFailover = () => {
       <Text color="yellow">{Label.TRYING_OTHER_MIRRORS}</Text>
       {mirrorCheckStates.map((mirror) => (
         <Box key={mirror.src}>
-          <Text color="gray">  </Text>
+          <Text color="gray"> </Text>
           {mirror.status === "checking" && (
             <Text color="yellow">
               <Spinner />

--- a/src/tui/hooks/use-stdout-dimensions.tsx
+++ b/src/tui/hooks/use-stdout-dimensions.tsx
@@ -13,7 +13,7 @@ export function useStdoutDimensions(): [number, number] {
     if (!stdout) {
       return;
     }
-    
+
     const handler = () => setDimensions([stdout.columns, stdout.rows]);
     stdout.on("resize", handler);
     return () => {

--- a/src/tui/store/app.ts
+++ b/src/tui/store/app.ts
@@ -89,7 +89,9 @@ export const initialAppState = {
 };
 
 export const createAppStateSlice = (
-  set: (partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)) => void,
+  set: (
+    partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)
+  ) => void,
   get: () => TCombinedStore
 ) => ({
   CLIMode: false,

--- a/src/tui/store/bulk-download-queue.ts
+++ b/src/tui/store/bulk-download-queue.ts
@@ -50,7 +50,9 @@ export const initialBulkDownloadQueueState = {
 };
 
 export const createBulkDownloadQueueStateSlice = (
-  set: (partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)) => void,
+  set: (
+    partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)
+  ) => void,
   get: () => TCombinedStore
 ) => ({
   ...initialBulkDownloadQueueState,
@@ -183,7 +185,6 @@ export const createBulkDownloadQueueStateSlice = (
   operateBulkDownloadQueue: async () => {
     const bulkDownloadQueue = get().bulkDownloadQueue;
     for (const [index, item] of bulkDownloadQueue.entries()) {
-
       const detailPageUrl = get().mirrorAdapter?.getDetailPageURL(item.md5);
       if (!detailPageUrl) {
         get().setWarningMessage(`Couldn't get the detail page URL for ${item.md5}`);
@@ -200,7 +201,9 @@ export const createBulkDownloadQueueStateSlice = (
         continue;
       }
 
-      const downloadUrl = get().mirrorAdapter?.getMainDownloadURLFromDocument(detailPageResult.document);
+      const downloadUrl = get().mirrorAdapter?.getMainDownloadURLFromDocument(
+        detailPageResult.document
+      );
       if (!downloadUrl) {
         get().setWarningMessage(`Couldn't find the download url for ${item.md5}`);
         get().onBulkQueueItemFail(index);

--- a/src/tui/store/cache.ts
+++ b/src/tui/store/cache.ts
@@ -14,7 +14,9 @@ export const initialCacheState = {
 };
 
 export const createCacheStateSlice = (
-  set: (partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)) => void,
+  set: (
+    partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)
+  ) => void,
   get: () => TCombinedStore
 ) => ({
   ...initialCacheState,

--- a/src/tui/store/config.ts
+++ b/src/tui/store/config.ts
@@ -25,7 +25,9 @@ export const initialConfigState: Omit<IConfigState, "fetchConfig" | "switchMirro
 };
 
 export const createConfigStateSlice = (
-  set: (partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)) => void,
+  set: (
+    partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)
+  ) => void,
   get: () => TCombinedStore
 ) => ({
   ...initialConfigState,

--- a/src/tui/store/download-queue.ts
+++ b/src/tui/store/download-queue.ts
@@ -45,7 +45,9 @@ export const initialDownloadQueueState = {
 };
 
 export const createDownloadQueueStateSlice = (
-  set: (partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)) => void,
+  set: (
+    partial: Partial<TCombinedStore> | ((state: TCombinedStore) => Partial<TCombinedStore>)
+  ) => void,
   get: () => TCombinedStore
 ) => ({
   ...initialDownloadQueueState,
@@ -130,7 +132,9 @@ export const createDownloadQueueStateSlice = (
         continue;
       }
 
-      const downloadUrl = store.mirrorAdapter?.getMainDownloadURLFromDocument(mirrorPageResult.document);
+      const downloadUrl = store.mirrorAdapter?.getMainDownloadURLFromDocument(
+        mirrorPageResult.document
+      );
 
       if (!downloadUrl) {
         store.setWarningMessage(`Couldn't find the download url for "${entry.title}"`);
@@ -197,11 +201,16 @@ export const createDownloadQueueStateSlice = (
           ...previous.downloadProgressMap[entryId],
           ...downloadProgress,
           progress: (() => {
+            if (!("progress" in downloadProgress)) {
+              return previous.downloadProgressMap[entryId]?.progress;
+            }
             if (downloadProgress.progress === undefined) {
               return 0;
             }
-            return (previous.downloadProgressMap[entryId]?.progress || 0) +
-              (downloadProgress.progress || 0);
+            return (
+              (previous.downloadProgressMap[entryId]?.progress || 0) +
+              (downloadProgress.progress || 0)
+            );
           })(),
         },
       },

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -38,8 +38,8 @@ export async function attempt<T>(
       }
       await delay(FAIL_REQ_ATTEMPT_DELAY_MS);
       if (index + 1 === FAIL_REQ_ATTEMPT_COUNT && onError) {
-          onError((error as Error)?.message);
-        }
+        onError((error as Error)?.message);
+      }
     }
   }
   return undefined;
@@ -94,9 +94,7 @@ const getNextPageOption = (
       ];
     }
     case "error": {
-      return [
-        createOptionItem(Option.NEXT_PAGE, Label.NEXT_PAGE_ERROR, handleRetryNextPageOption),
-      ];
+      return [createOptionItem(Option.NEXT_PAGE, Label.NEXT_PAGE_ERROR, handleRetryNextPageOption)];
     }
     case "unavailable": {
       return [
@@ -129,20 +127,18 @@ export const constructListItems = ({
   }));
 
   return [
-    ...entryListItems.slice(
-      entryListItems.length - RESULT_LIST_ACTIVE_LIST_INDEX
-    ),
+    ...entryListItems.slice(entryListItems.length - RESULT_LIST_ACTIVE_LIST_INDEX),
 
     createOptionItem(Option.SEARCH, Label.SEARCH, handleSearchOption),
 
     ...getNextPageOption(nextPageStatus, handleNextPageOption, handleRetryNextPageOption),
 
-    ...((() => {
+    ...(() => {
       if (currentPage > 1) {
         return [createOptionItem(Option.PREV_PAGE, Label.PREV_PAGE, handlePrevPageOption)];
       }
       return [];
-    })()),
+    })(),
 
     createOptionItem(
       Option.START_BULK_DOWNLOAD,

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, mock } from "bun:test";
+import { parseHTML } from "linkedom";
+import { LibgenPlusAdapter } from "../src/api/adapters/libgen-plus-adapter";
+
+const parseDocument = (html: string) => parseHTML(html).document as unknown as Document;
+
+describe("LibgenPlusAdapter", () => {
+  const adapter = new LibgenPlusAdapter("https://libgen.example/");
+
+  it("constructs search, detail, and relative page URLs", () => {
+    expect(adapter.getSearchURL("clean code", 2, 25)).toBe(
+      "https://libgen.example/index.php?req=clean+code&page=2&res=25"
+    );
+    expect(adapter.getDetailPageURL("abc123")).toBe("https://libgen.example/ads.php?md5=abc123");
+    expect(adapter.getPageURL("/book.epub")).toBe("https://libgen.example/book.epub");
+  });
+
+  it("parses result rows into normalized entries", () => {
+    const document = parseDocument(`
+      <table id="tablelibgen">
+        <tbody>
+          <tr>
+            <td><a>Primary Title</a><span>Subtitle</span><nobr>ignored</nobr></td>
+            <td>Alice Example; Bob Example</td>
+            <td>Example Press</td>
+            <td>2026</td>
+            <td>English</td>
+            <td>321</td>
+            <td>2 MB</td>
+            <td>epub</td>
+            <td><a href="/ads.php?md5=abc123">Mirror</a></td>
+          </tr>
+        </tbody>
+      </table>
+    `);
+
+    const entries = adapter.parseEntries(document);
+
+    expect(entries).toHaveLength(1);
+    expect(entries?.[0]).toMatchObject({
+      authors: "Alice Example, Bob Example",
+      title: "Primary Title / Subtitle",
+      publisher: "Example Press",
+      year: "2026",
+      language: "English",
+      pages: "321",
+      size: "2 MB",
+      extension: "epub",
+      mirror: "/ads.php?md5=abc123",
+    });
+    expect(entries?.[0].id).toBeTruthy();
+  });
+
+  it("extracts the primary download URL and connection errors", () => {
+    const document = parseDocument(`
+      <table id="main"><tr><td>Book</td><td><a href="/get/book.epub">GET</a></td></tr></table>
+      <div class="alert-danger">Mirror temporarily unavailable</div>
+    `);
+
+    expect(adapter.getMainDownloadURLFromDocument(document)).toBe(
+      "https://libgen.example/get/book.epub"
+    );
+    expect(adapter.detectConnectionError(document)).toBe("Mirror temporarily unavailable");
+  });
+
+  it("returns an empty result and reports malformed result pages", () => {
+    const onError = mock(() => {});
+
+    expect(adapter.parseEntries(parseDocument("<main>no results table</main>"), onError)).toEqual(
+      []
+    );
+    expect(onError).toHaveBeenCalledWith("containerTable is undefined");
+  });
+});

--- a/test/data.test.ts
+++ b/test/data.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { fetchConfig, findMirror } from "../src/api/data/config";
+import { getDocument } from "../src/api/data/document";
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("configuration data", () => {
+  it("normalizes the remote configuration response", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        latest_version: "4.0.0",
+        mirrors: [{ src: "https://mirror.example/", type: "libgen-plus" }],
+      })
+    );
+
+    await expect(fetchConfig()).resolves.toEqual({
+      latestVersion: "4.0.0",
+      mirrors: [{ src: "https://mirror.example/", type: "libgen-plus" }],
+    });
+  });
+
+  it("wraps configuration transport errors", async () => {
+    spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    await expect(fetchConfig()).rejects.toThrow("Error occurred while fetching configuration.");
+  });
+
+  it("selects the first reachable mirror and reports failed mirrors", async () => {
+    const onMirrorFail = mock(() => {});
+    const fetchMock = spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(new Response("ok"));
+    const mirrors = [
+      { src: "https://offline.example/", type: "libgen-plus" as const },
+      { src: "https://online.example/", type: "libgen-plus" as const },
+    ];
+
+    await expect(findMirror(mirrors, onMirrorFail)).resolves.toEqual(mirrors[1]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onMirrorFail).toHaveBeenCalledWith("https://offline.example/");
+  });
+});
+
+describe("document data", () => {
+  it("fetches HTML and returns a queryable document", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('<main><h1 id="title">Example Book</h1></main>')
+    );
+
+    const result = await getDocument("https://mirror.example/book");
+
+    expect(result.htmlString).toContain("Example Book");
+    expect(result.document.querySelector("#title")?.textContent).toBe("Example Book");
+  });
+
+  it("wraps document transport errors with the requested URL", async () => {
+    spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    await expect(getDocument("https://mirror.example/book")).rejects.toThrow(
+      "Error occured while fetching document of https://mirror.example/book"
+    );
+  });
+});

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import fs from "node:fs";
+import { Writable } from "node:stream";
+import { downloadFile } from "../src/api/data/download";
+
+const createResponse = (filename: string, chunks: Uint8Array[]) => {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
+    headers: {
+      "content-disposition": `attachment; filename="${filename}"`,
+      "content-length": String(chunks.reduce((total, chunk) => total + chunk.length, 0)),
+    },
+  });
+};
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("downloadFile", () => {
+  it("writes every response chunk and reports progress", async () => {
+    const writtenChunks: Buffer[] = [];
+    const destination = new Writable({
+      write(chunk: Buffer, _encoding, callback) {
+        writtenChunks.push(Buffer.from(chunk));
+        callback();
+      },
+    });
+    spyOn(fs, "createWriteStream").mockReturnValue(destination as fs.WriteStream);
+
+    const onStart = mock(() => {});
+    const onData = mock(() => {});
+    const chunks = [Buffer.from("first "), Buffer.from("second")];
+
+    const result = await downloadFile({
+      downloadStream: createResponse("example.epub", chunks),
+      onStart,
+      onData,
+    });
+
+    expect(result).toEqual({
+      path: "./example.epub",
+      filename: "example.epub",
+      total: 12,
+    });
+    expect(Buffer.concat(writtenChunks).toString()).toBe("first second");
+    expect(onStart).toHaveBeenCalledWith("example.epub", 12);
+    expect(onData).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when the response has no content-disposition header", async () => {
+    await expect(
+      downloadFile({
+        downloadStream: new Response("content"),
+        onStart() {},
+        onData() {},
+      })
+    ).rejects.toThrow("No content-disposition header found");
+  });
+
+  it("handles a destroyed destination without writing to it again", async () => {
+    const destination = new Writable({
+      write(_chunk, _encoding, callback) {
+        setTimeout(() => {
+          destination.destroy();
+        }, 0);
+        callback();
+      },
+    });
+    spyOn(fs, "createWriteStream").mockReturnValue(destination as fs.WriteStream);
+
+    let cancelled = false;
+    let pullCount = 0;
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (pullCount === 0) {
+          pullCount += 1;
+          controller.enqueue(Buffer.alloc(1024));
+          return;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        if (!cancelled) {
+          controller.enqueue(Buffer.alloc(1024));
+          controller.close();
+        }
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const downloadStream = new Response(body, {
+      headers: {
+        "content-disposition": 'attachment; filename="broken.epub"',
+        "content-length": "2048",
+      },
+    });
+
+    await expect(
+      downloadFile({
+        downloadStream,
+        onStart() {},
+        onData() {},
+      })
+    ).rejects.toThrow("(broken.epub) Error occurred while downloading file");
+  });
+});

--- a/test/queue.integration.test.ts
+++ b/test/queue.integration.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import fs from "node:fs";
+import { Writable } from "node:stream";
+import { LibgenPlusAdapter } from "../src/api/adapters/libgen-plus-adapter";
+import type { Entry } from "../src/api/models/entry";
+import { DownloadStatus } from "../src/download-statuses";
+import { initialAppState } from "../src/tui/store/app";
+import { initialBulkDownloadQueueState } from "../src/tui/store/bulk-download-queue";
+import { initialConfigState } from "../src/tui/store/config";
+import { initialDownloadQueueState } from "../src/tui/store/download-queue";
+import { useBoundStore } from "../src/tui/store";
+
+const BASE_URL = "https://libgen.example/";
+const originalStoreState = useBoundStore.getState();
+
+const getRequestURL = (input: RequestInfo | URL): string => {
+  switch (true) {
+    case input instanceof Request: {
+      return input.url;
+    }
+    default: {
+      return input.toString();
+    }
+  }
+};
+
+const createEntry = (id: string, md5: string): Entry => ({
+  id,
+  authors: "Example Author",
+  title: `Example Book ${id}`,
+  publisher: "Example Press",
+  year: "2026",
+  pages: "100",
+  language: "English",
+  size: "1 KB",
+  extension: "epub",
+  mirror: `/ads.php?md5=${md5}`,
+});
+
+const installNetworkFixture = () => {
+  const requestedURLs: string[] = [];
+  const fixtureFetch = Object.assign(
+    async (input: RequestInfo | URL) => {
+      const url = getRequestURL(input);
+      requestedURLs.push(url);
+
+      if (url.includes("/ads.php?md5=success")) {
+        return new Response(
+          '<table id="main"><tr><td>Book</td><td><a href="/files/success.epub">GET</a></td></tr></table>'
+        );
+      }
+
+      if (url.includes("/ads.php?md5=missing")) {
+        return new Response("<main>Download link unavailable</main>");
+      }
+
+      if (url.endsWith("/files/success.epub")) {
+        return new Response("downloaded content", {
+          headers: {
+            "content-disposition": 'attachment; filename="success.epub"',
+            "content-length": "18",
+          },
+        });
+      }
+
+      return new Response("Not found", { status: 404 });
+    },
+    { preconnect() {} }
+  );
+  const fetchMock = spyOn(globalThis, "fetch").mockImplementation(fixtureFetch);
+
+  return { fetchMock, requestedURLs };
+};
+
+const installFilesystemFixture = () => {
+  const downloadedChunks: Buffer[] = [];
+  const createWriteStream = spyOn(fs, "createWriteStream").mockImplementation(() => {
+    return new Writable({
+      write(chunk: Buffer, _encoding, callback) {
+        downloadedChunks.push(Buffer.from(chunk));
+        callback();
+      },
+    }) as fs.WriteStream;
+  });
+  const writeFile = spyOn(fs.promises, "writeFile").mockImplementation(async () => {});
+
+  return { createWriteStream, downloadedChunks, writeFile };
+};
+
+beforeEach(() => {
+  useBoundStore.setState(
+    {
+      ...originalStoreState,
+      ...initialAppState,
+      ...initialConfigState,
+      ...initialDownloadQueueState,
+      ...initialBulkDownloadQueueState,
+      CLIMode: false,
+      mirror: { src: BASE_URL, type: "libgen-plus" },
+      mirrorAdapter: new LibgenPlusAdapter(BASE_URL),
+      setWarningMessage: mock(() => {}),
+    },
+    true
+  );
+});
+
+afterEach(() => {
+  mock.restore();
+  useBoundStore.setState(originalStoreState, true);
+});
+
+describe("download queue integration", () => {
+  it("deduplicates entries before starting the queue", () => {
+    const iterateQueue = mock(async () => {});
+    useBoundStore.setState({ iterateQueue });
+    const entry = createEntry("entry-1", "success");
+
+    useBoundStore.getState().pushDownloadQueue(entry);
+    useBoundStore.getState().pushDownloadQueue(entry);
+
+    const state = useBoundStore.getState();
+    expect(state.downloadQueue).toEqual([entry]);
+    expect(state.inDownloadQueueEntryIds).toEqual([entry.id]);
+    expect(state.totalAddedToDownloadQueue).toBe(1);
+    expect(state.downloadProgressMap[entry.id]?.status).toBe(DownloadStatus.IN_QUEUE);
+    expect(iterateQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves a mirror page, downloads the file, and completes the queue item", async () => {
+    const { fetchMock, requestedURLs } = installNetworkFixture();
+    const { createWriteStream, downloadedChunks } = installFilesystemFixture();
+    const entry = createEntry("entry-1", "success");
+    useBoundStore.setState({
+      downloadQueue: [entry],
+      inDownloadQueueEntryIds: [entry.id],
+    });
+
+    await useBoundStore.getState().iterateQueue();
+
+    const state = useBoundStore.getState();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestedURLs).toEqual([
+      "https://libgen.example/ads.php?md5=success",
+      "https://libgen.example/files/success.epub",
+    ]);
+    expect(createWriteStream).toHaveBeenCalledWith("./success.epub");
+    expect(Buffer.concat(downloadedChunks).toString()).toBe("downloaded content");
+    expect(state.downloadProgressMap[entry.id]).toMatchObject({
+      filename: "success.epub",
+      progress: 18,
+      total: 18,
+      status: DownloadStatus.DOWNLOADED,
+    });
+    expect(state.totalDownloaded).toBe(1);
+    expect(state.totalFailed).toBe(0);
+    expect(state.inDownloadQueueEntryIds).toEqual([]);
+    expect(state.isQueueActive).toBe(false);
+  });
+});
+
+describe("bulk download integration", () => {
+  it("builds a bulk queue from selected entries before processing", async () => {
+    const operateBulkDownloadQueue = mock(async () => {});
+    const validEntry = createEntry("entry-1", "success");
+    const invalidEntry = { ...createEntry("entry-2", "missing"), mirror: "/ads.php" };
+    useBoundStore.setState({
+      CLIMode: true,
+      bulkDownloadSelectedEntries: {
+        valid: validEntry,
+        invalid: invalidEntry,
+      },
+      operateBulkDownloadQueue,
+    });
+
+    await useBoundStore.getState().startBulkDownload();
+
+    const state = useBoundStore.getState();
+    expect(state.bulkDownloadQueue).toEqual([
+      {
+        md5: "success",
+        filename: "",
+        total: 0,
+        progress: 0,
+        status: DownloadStatus.IN_QUEUE,
+      },
+    ]);
+    expect(operateBulkDownloadQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("processes successful and failed items and records only completed MD5s", async () => {
+    const { fetchMock } = installNetworkFixture();
+    const { downloadedChunks, writeFile } = installFilesystemFixture();
+    useBoundStore.setState({
+      bulkDownloadQueue: [
+        {
+          md5: "success",
+          filename: "",
+          total: 0,
+          progress: 0,
+          status: DownloadStatus.IN_QUEUE,
+        },
+        {
+          md5: "missing",
+          filename: "",
+          total: 0,
+          progress: 0,
+          status: DownloadStatus.IN_QUEUE,
+        },
+      ],
+    });
+
+    await useBoundStore.getState().operateBulkDownloadQueue();
+
+    const state = useBoundStore.getState();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(state.bulkDownloadQueue).toMatchObject([
+      {
+        md5: "success",
+        filename: "success.epub",
+        progress: 18,
+        total: 18,
+        status: DownloadStatus.DOWNLOADED,
+      },
+      {
+        md5: "missing",
+        status: DownloadStatus.FAILED,
+      },
+    ]);
+    expect(Buffer.concat(downloadedChunks).toString()).toBe("downloaded content");
+    expect(state.completedBulkDownloadItemCount).toBe(1);
+    expect(state.failedBulkDownloadItemCount).toBe(1);
+    expect(state.isBulkDownloadComplete).toBe(true);
+    expect(state.createdMD5ListFileName).toMatch(/^libgen_downloader_md5_list_\d+\.txt$/);
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(writeFile.mock.calls[0]?.[0].toString()).toMatch(
+      /^\.\/libgen_downloader_md5_list_\d+\.txt$/
+    );
+    expect(writeFile.mock.calls[0]?.[1]).toBe("success");
+  });
+});

--- a/test/search.integration.test.ts
+++ b/test/search.integration.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { LibgenPlusAdapter } from "../src/api/adapters/libgen-plus-adapter";
+import type { Entry } from "../src/api/models/entry";
+import Label from "../src/labels";
+import { initialAppState } from "../src/tui/store/app";
+import { initialBulkDownloadQueueState } from "../src/tui/store/bulk-download-queue";
+import { initialCacheState } from "../src/tui/store/cache";
+import { initialConfigState } from "../src/tui/store/config";
+import { initialDownloadQueueState } from "../src/tui/store/download-queue";
+import { useBoundStore } from "../src/tui/store";
+import { LAYOUT_KEY } from "../src/tui/layouts/keys";
+
+const BASE_URL = "https://libgen.example/";
+const originalStoreState = useBoundStore.getState();
+
+const entry: Entry = {
+  id: "cached-entry",
+  authors: "Example Author",
+  title: "Cached Book",
+  publisher: "Example Press",
+  year: "2026",
+  pages: "100",
+  language: "English",
+  size: "1 MB",
+  extension: "epub",
+  mirror: "/ads.php?md5=cached",
+};
+
+const searchResultHTML = `
+  <table id="tablelibgen">
+    <tbody>
+      <tr>
+        <td><a>Search Result</a></td>
+        <td>Search Author</td>
+        <td>Search Press</td>
+        <td>2026</td>
+        <td>English</td>
+        <td>200</td>
+        <td>2 MB</td>
+        <td>pdf</td>
+        <td><a href="/ads.php?md5=result">Mirror</a></td>
+      </tr>
+    </tbody>
+  </table>
+`;
+
+beforeEach(() => {
+  useBoundStore.setState(
+    {
+      ...originalStoreState,
+      ...initialAppState,
+      ...initialConfigState,
+      ...initialCacheState,
+      ...initialDownloadQueueState,
+      ...initialBulkDownloadQueueState,
+      CLIMode: true,
+      mirror: { src: BASE_URL, type: "libgen-plus" },
+      mirrors: [{ src: BASE_URL, type: "libgen-plus" }],
+      mirrorAdapter: new LibgenPlusAdapter(BASE_URL),
+      setWarningMessage: mock(() => {}),
+    },
+    true
+  );
+});
+
+afterEach(() => {
+  mock.restore();
+  useBoundStore.setState(originalStoreState, true);
+});
+
+describe("search integration", () => {
+  it("parses remote results, caches them, and reuses the cache", async () => {
+    const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(new Response(searchResultHTML));
+    useBoundStore.setState({ searchValue: "typescript" });
+
+    const firstResult = await useBoundStore.getState().search("typescript", 1);
+    const secondResult = await useBoundStore.getState().search("typescript", 1);
+
+    expect(firstResult.status).toBe("success");
+    expect(firstResult).toMatchObject({
+      entries: [
+        {
+          title: "Search Result",
+          authors: "Search Author",
+          mirror: "/ads.php?md5=result",
+        },
+      ],
+    });
+    expect(secondResult).toEqual(firstResult);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    if (firstResult.status !== "success") {
+      throw new Error("Expected the initial search to succeed");
+    }
+    expect(
+      useBoundStore.getState().entryCacheMap[
+        "https://libgen.example/index.php?req=typescript&page=1&res=25"
+      ]
+    ).toEqual(firstResult.entries);
+  });
+
+  it("returns a connection error reported by the active mirror", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('<div class="alert-danger">Database is unavailable</div>')
+    );
+    useBoundStore.setState({ searchValue: "typescript" });
+
+    await expect(useBoundStore.getState().search("typescript", 1)).resolves.toEqual({
+      status: "connection_error",
+      message: "Database is unavailable",
+    });
+  });
+
+  it("submits a search and transitions to populated result state", async () => {
+    const search = mock(async () => ({ status: "success" as const, entries: [entry] }));
+    const checkNextPage = mock(() => {});
+    useBoundStore.setState({
+      searchValue: "typescript",
+      search,
+      checkNextPage,
+    });
+
+    await useBoundStore.getState().handleSearchSubmit();
+
+    const state = useBoundStore.getState();
+    expect(search).toHaveBeenCalledWith("typescript", 1);
+    expect(state.activeLayout).toBe(LAYOUT_KEY.RESULT_LIST_LAYOUT);
+    expect(state.entries).toEqual([entry]);
+    expect(state.isLoading).toBe(false);
+    expect(checkNextPage).toHaveBeenCalledWith("typescript", 2);
+  });
+
+  it("reports an unrecoverable connection error when no fallback mirror exists", async () => {
+    const search = mock(async () => ({
+      status: "connection_error" as const,
+      message: "Active mirror failed",
+    }));
+    useBoundStore.setState({ searchValue: "typescript", search });
+
+    await useBoundStore.getState().handleSearchSubmit();
+
+    const state = useBoundStore.getState();
+    expect(state.connectionError).toBe("Active mirror failed");
+    expect(state.errorMessage).toBe(Label.ALL_MIRRORS_FAILED);
+    expect(state.isLoading).toBe(false);
+  });
+
+  it("moves to a cached next page and schedules the following page check", async () => {
+    const lookupPageCache = mock(() => [entry]);
+    const checkNextPage = mock(() => {});
+    useBoundStore.setState({
+      currentPage: 1,
+      searchValue: "typescript",
+      lookupPageCache,
+      checkNextPage,
+    });
+
+    await useBoundStore.getState().nextPage();
+
+    const state = useBoundStore.getState();
+    expect(lookupPageCache).toHaveBeenCalledWith(2);
+    expect(state.currentPage).toBe(2);
+    expect(state.entries).toEqual([entry]);
+    expect(state.listItemsCursor).toBe(0);
+    expect(state.nextPageStatus).toBe("idle");
+    expect(state.isLoading).toBe(false);
+    expect(checkNextPage).toHaveBeenCalledWith("typescript", 3);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "moduleDetection": "force",
     "jsx": "react-jsx",
-    "outDir": "./build",
+    "noEmit": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
@@ -15,8 +16,8 @@
     "noImplicitReturns": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "types": ["bun-types"]
+    "types": ["bun"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "build", "standalone-executables"]
 }


### PR DESCRIPTION
## Summary

- replace manual response-stream writes with a Node-compatible `pipeline` using `node:stream`
- preserve accumulated queue progress when status-only updates are applied
- resolve strict TypeScript and Prettier issues across the project
- add unit and integration coverage for downloads, search, adapters, configuration, queues, and bulk downloads
- add pull request CI for changes targeting `master`

## Why

The download implementation manually wrote chunks to an `fs.WriteStream` and managed completion separately. When the destination stream failed or was destroyed, later writes could emit an unhandled `ERR_STREAM_DESTROYED` error, particularly on newer Node.js versions. Using `pipeline` centralizes backpressure, completion, and error propagation while remaining compatible with Bun and the Node-targeted bundle.

The project also lacked automated coverage around its core download flows and did not validate pull requests consistently.

## Impact

Downloads now fail through the existing error path instead of continuing to write to a destroyed stream. Search, single-download, and bulk-download behavior are covered by deterministic tests with mocked network and filesystem boundaries. Pull requests targeting `master` now run typechecking, tests, linting, formatting checks, and a Node bundle smoke test.

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run test` — 21 tests passed
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `node build/index.js --help`
- standalone Bun macOS ARM64 compilation and smoke test
- workflow YAML parsing
- test coverage: 79.07% lines

Closes #93
