### PR TITLE
Fix missing header, Introduce request timeouts and AbortSignal handling

### DIFF
--- a/src/api/data/config.ts
+++ b/src/api/data/config.ts
@@ -1,4 +1,6 @@
 import { CONFIGURATION_URL } from "../../settings";
+import { attempt } from "../../utilities";
+import type { AttemptOptions } from "../../utilities";
 
 export type MirrorType = "libgen-plus";
 
@@ -12,9 +14,9 @@ export interface Config {
   mirrors: Mirror[];
 }
 
-export async function fetchConfig(): Promise<Config> {
+export async function fetchConfig(signal: AbortSignal): Promise<Config> {
   try {
-    const response = await fetch(CONFIGURATION_URL);
+    const response = await fetch(CONFIGURATION_URL, { signal });
     const json = await response.json();
     const config = json as Record<string, unknown>;
 
@@ -29,15 +31,16 @@ export async function fetchConfig(): Promise<Config> {
 
 export async function findMirror(
   mirrors: Mirror[],
-  onMirrorFail: (failedMirror: string) => void
+  onMirrorFail: (failedMirror: string) => void,
+  attemptOptions?: AttemptOptions
 ): Promise<Mirror | undefined> {
   for (const mirror of mirrors) {
-    try {
-      await fetch(mirror.src);
+    const response = await attempt((signal) => fetch(mirror.src, { signal }), attemptOptions);
+    if (response) {
       return mirror;
-    } catch {
-      onMirrorFail(mirror.src);
     }
+
+    onMirrorFail(mirror.src);
   }
   return undefined;
 }

--- a/src/api/data/document.ts
+++ b/src/api/data/document.ts
@@ -1,13 +1,19 @@
 import { parseHTML } from "linkedom";
+import { LIBGEN_USER_AGENT } from "../../settings";
 
 export interface DocumentResult {
   document: Document;
   htmlString: string;
 }
 
-export async function getDocument(searchURL: string): Promise<DocumentResult> {
+export async function getDocument(searchURL: string, signal: AbortSignal): Promise<DocumentResult> {
   try {
-    const response = await fetch(searchURL);
+    const response = await fetch(searchURL, {
+      headers: {
+        "User-Agent": LIBGEN_USER_AGENT,
+      },
+      signal,
+    });
     const htmlString = await response.text();
     const { document } = parseHTML(htmlString);
     return { document: document as unknown as Document, htmlString };

--- a/src/cli/operate.ts
+++ b/src/cli/operate.ts
@@ -54,7 +54,7 @@ export const operate = async (flags: Record<string, unknown>) => {
       return;
     }
 
-    const detailPageResult = await attempt(() => getDocument(detailPageUrl));
+    const detailPageResult = await attempt((signal) => getDocument(detailPageUrl, signal));
     if (!detailPageResult) {
       console.log("Failed to get detail page document");
       return;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,5 @@
+import { version } from "../package.json";
+
 export const SCREEN_BASE_APP_WIDTH = 80;
 export const SCREEN_PADDING = 5;
 export const SCREEN_WIDTH_PERC = 95;
@@ -7,5 +9,8 @@ export const CONFIGURATION_URL =
 
 export const FAIL_REQ_ATTEMPT_COUNT = 5;
 export const FAIL_REQ_ATTEMPT_DELAY_MS = 2000;
+export const REQUEST_TIMEOUT_MS = 10_000;
 
 export const SEARCH_PAGE_SIZE = 25;
+
+export const LIBGEN_USER_AGENT = `libgen-downloader/${version}`;

--- a/src/tui/store/bulk-download-queue.ts
+++ b/src/tui/store/bulk-download-queue.ts
@@ -194,7 +194,7 @@ export const createBulkDownloadQueueStateSlice = (
 
       get().onBulkQueueItemProcessing(index);
 
-      const detailPageResult = await attempt(() => getDocument(detailPageUrl));
+      const detailPageResult = await attempt((signal) => getDocument(detailPageUrl, signal));
       if (!detailPageResult) {
         get().setWarningMessage(`Couldn't fetch the detail page for ${item.md5}`);
         get().onBulkQueueItemFail(index);
@@ -210,7 +210,7 @@ export const createBulkDownloadQueueStateSlice = (
         continue;
       }
 
-      const downloadStream = await attempt(() => fetch(downloadUrl));
+      const downloadStream = await attempt((signal) => fetch(downloadUrl, { signal }));
       if (!downloadStream) {
         get().setWarningMessage(`Couldn't fetch the download stream for ${item.md5}`);
         get().onBulkQueueItemFail(index);

--- a/src/tui/store/config.ts
+++ b/src/tui/store/config.ts
@@ -86,7 +86,11 @@ export const createConfigStateSlice = (
       try {
         const adapter = getAdapter(mirror.src, mirror.type);
         const testURL = adapter.getSearchURL("test", 1, SEARCH_PAGE_SIZE);
-        const result = await getDocument(testURL);
+        const result = await attempt((signal) => getDocument(testURL, signal));
+        if (!result) {
+          onMirrorStatus(mirror.src, "failed");
+          continue;
+        }
         const connectionError = adapter.detectConnectionError(result.document);
 
         if (connectionError) {

--- a/src/tui/store/download-queue.ts
+++ b/src/tui/store/download-queue.ts
@@ -125,7 +125,7 @@ export const createDownloadQueueStateSlice = (
         continue;
       }
 
-      const mirrorPageResult = await attempt(() => getDocument(detailPageUrl));
+      const mirrorPageResult = await attempt((signal) => getDocument(detailPageUrl, signal));
       if (!mirrorPageResult) {
         store.setWarningMessage(`Couldn't fetch the mirror page for "${entry.title}"`);
         store.increaseTotalFailed();
@@ -142,7 +142,7 @@ export const createDownloadQueueStateSlice = (
         continue;
       }
 
-      const downloadStream = await attempt(() => fetch(downloadUrl as string));
+      const downloadStream = await attempt((signal) => fetch(downloadUrl as string, { signal }));
       if (!downloadStream) {
         store.setWarningMessage(`Couldn't fetch the download stream for "${entry.title}"`);
         store.increaseTotalFailed();

--- a/src/tui/store/events.ts
+++ b/src/tui/store/events.ts
@@ -46,7 +46,7 @@ export const createEventActionsSlice = (
       return { status: "success", entries: cachedEntries };
     }
 
-    const pageDocumentResult = await attempt(() => getDocument(searchURL));
+    const pageDocumentResult = await attempt((signal) => getDocument(searchURL, signal));
     if (!pageDocumentResult) {
       return { status: "error", message: `Couldn't fetch the search page for "${query}"` };
     }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -7,7 +7,7 @@ import {
 } from "./constants";
 import { Option } from "./options";
 import Label from "./labels";
-import { FAIL_REQ_ATTEMPT_COUNT, FAIL_REQ_ATTEMPT_DELAY_MS } from "./settings";
+import { FAIL_REQ_ATTEMPT_COUNT, FAIL_REQ_ATTEMPT_DELAY_MS, REQUEST_TIMEOUT_MS } from "./settings";
 
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -17,31 +17,56 @@ export function delay(ms: number): Promise<void> {
   });
 }
 
-export async function attempt<T>(
-  callback: () => Promise<T>,
-  onFail?: (message: string) => void,
-  onError?: (message: string) => void,
-  onComplete?: () => void
-): Promise<T | undefined> {
-  for (let index = 0; index < FAIL_REQ_ATTEMPT_COUNT; index++) {
-    try {
-      const result = await callback();
+export interface AttemptOptions {
+  attemptCount?: number;
+  delayMs?: number;
+  timeoutMs?: number;
+  onFail?: (message: string) => void;
+  onError?: (message: string) => void;
+  onComplete?: () => void;
+}
 
-      if (onComplete) {
-        onComplete();
+export async function attempt<T>(
+  callback: (signal: AbortSignal) => Promise<T>,
+  options: AttemptOptions = {}
+): Promise<T | undefined> {
+  const attemptCount = options.attemptCount ?? FAIL_REQ_ATTEMPT_COUNT;
+  const delayMs = options.delayMs ?? FAIL_REQ_ATTEMPT_DELAY_MS;
+  const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS;
+
+  for (let index = 0; index < attemptCount; index++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let failure: unknown;
+
+    try {
+      const result = await callback(controller.signal);
+
+      if (options.onComplete) {
+        options.onComplete();
       }
 
       return result;
     } catch (error: unknown) {
-      if (onFail) {
-        onFail(`Request failed, trying again ${index + 1}/${FAIL_REQ_ATTEMPT_COUNT}`);
+      failure = error;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (options.onFail) {
+      options.onFail(`Request failed, trying again ${index + 1}/${attemptCount}`);
+    }
+
+    const isLastAttempt = index + 1 === attemptCount;
+    if (isLastAttempt) {
+      if (options.onError) {
+        options.onError((failure as Error)?.message);
       }
-      await delay(FAIL_REQ_ATTEMPT_DELAY_MS);
-      if (index + 1 === FAIL_REQ_ATTEMPT_COUNT && onError) {
-        onError((error as Error)?.message);
-      }
+    } else {
+      await delay(delayMs);
     }
   }
+
   return undefined;
 }
 

--- a/test/data.test.ts
+++ b/test/data.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { fetchConfig, findMirror } from "../src/api/data/config";
 import { getDocument } from "../src/api/data/document";
+import { CONFIGURATION_URL, LIBGEN_USER_AGENT } from "../src/settings";
 
 afterEach(() => {
   mock.restore();
@@ -8,23 +9,27 @@ afterEach(() => {
 
 describe("configuration data", () => {
   it("normalizes the remote configuration response", async () => {
-    spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
       Response.json({
         latest_version: "4.0.0",
         mirrors: [{ src: "https://mirror.example/", type: "libgen-plus" }],
       })
     );
+    const signal = new AbortController().signal;
 
-    await expect(fetchConfig()).resolves.toEqual({
+    await expect(fetchConfig(signal)).resolves.toEqual({
       latestVersion: "4.0.0",
       mirrors: [{ src: "https://mirror.example/", type: "libgen-plus" }],
     });
+    expect(fetchMock).toHaveBeenCalledWith(CONFIGURATION_URL, { signal });
   });
 
   it("wraps configuration transport errors", async () => {
     spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
 
-    await expect(fetchConfig()).rejects.toThrow("Error occurred while fetching configuration.");
+    await expect(fetchConfig(new AbortController().signal)).rejects.toThrow(
+      "Error occurred while fetching configuration."
+    );
   });
 
   it("selects the first reachable mirror and reports failed mirrors", async () => {
@@ -37,20 +42,28 @@ describe("configuration data", () => {
       { src: "https://online.example/", type: "libgen-plus" as const },
     ];
 
-    await expect(findMirror(mirrors, onMirrorFail)).resolves.toEqual(mirrors[1]);
+    await expect(
+      findMirror(mirrors, onMirrorFail, { attemptCount: 1, delayMs: 0, timeoutMs: 100 })
+    ).resolves.toEqual(mirrors[1]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(onMirrorFail).toHaveBeenCalledWith("https://offline.example/");
   });
 });
 
 describe("document data", () => {
-  it("fetches HTML and returns a queryable document", async () => {
-    spyOn(globalThis, "fetch").mockResolvedValue(
+  it("fetches HTML with the application user agent and returns a queryable document", async () => {
+    const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
       new Response('<main><h1 id="title">Example Book</h1></main>')
     );
 
-    const result = await getDocument("https://mirror.example/book");
+    const url = "https://mirror.example/book";
+    const signal = new AbortController().signal;
+    const result = await getDocument(url, signal);
 
+    expect(fetchMock).toHaveBeenCalledWith(url, {
+      headers: { "User-Agent": LIBGEN_USER_AGENT },
+      signal,
+    });
     expect(result.htmlString).toContain("Example Book");
     expect(result.document.querySelector("#title")?.textContent).toBe("Example Book");
   });
@@ -58,8 +71,8 @@ describe("document data", () => {
   it("wraps document transport errors with the requested URL", async () => {
     spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
 
-    await expect(getDocument("https://mirror.example/book")).rejects.toThrow(
-      "Error occured while fetching document of https://mirror.example/book"
-    );
+    await expect(
+      getDocument("https://mirror.example/book", new AbortController().signal)
+    ).rejects.toThrow("Error occured while fetching document of https://mirror.example/book");
   });
 });

--- a/test/queue.integration.test.ts
+++ b/test/queue.integration.test.ts
@@ -39,10 +39,14 @@ const createEntry = (id: string, md5: string): Entry => ({
 
 const installNetworkFixture = () => {
   const requestedURLs: string[] = [];
+  const requestSignals: AbortSignal[] = [];
   const fixtureFetch = Object.assign(
-    async (input: RequestInfo | URL) => {
+    async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = getRequestURL(input);
       requestedURLs.push(url);
+      if (init?.signal) {
+        requestSignals.push(init.signal);
+      }
 
       if (url.includes("/ads.php?md5=success")) {
         return new Response(
@@ -69,7 +73,7 @@ const installNetworkFixture = () => {
   );
   const fetchMock = spyOn(globalThis, "fetch").mockImplementation(fixtureFetch);
 
-  return { fetchMock, requestedURLs };
+  return { fetchMock, requestedURLs, requestSignals };
 };
 
 const installFilesystemFixture = () => {
@@ -127,7 +131,7 @@ describe("download queue integration", () => {
   });
 
   it("resolves a mirror page, downloads the file, and completes the queue item", async () => {
-    const { fetchMock, requestedURLs } = installNetworkFixture();
+    const { fetchMock, requestedURLs, requestSignals } = installNetworkFixture();
     const { createWriteStream, downloadedChunks } = installFilesystemFixture();
     const entry = createEntry("entry-1", "success");
     useBoundStore.setState({
@@ -143,6 +147,8 @@ describe("download queue integration", () => {
       "https://libgen.example/ads.php?md5=success",
       "https://libgen.example/files/success.epub",
     ]);
+    expect(requestSignals).toHaveLength(2);
+    expect(requestSignals.every((signal) => !signal.aborted)).toBe(true);
     expect(createWriteStream).toHaveBeenCalledWith("./success.epub");
     expect(Buffer.concat(downloadedChunks).toString()).toBe("downloaded content");
     expect(state.downloadProgressMap[entry.id]).toMatchObject({

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { attempt } from "../src/utilities";
+
+describe("attempt", () => {
+  it("aborts timed-out work and retries with a fresh signal", async () => {
+    const signals: AbortSignal[] = [];
+
+    const result = await attempt(
+      (signal) => {
+        signals.push(signal);
+        if (signals.length > 1) {
+          return Promise.resolve("success");
+        }
+
+        return new Promise<string>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      },
+      { attemptCount: 2, delayMs: 0, timeoutMs: 5 }
+    );
+
+    expect(result).toBe("success");
+    expect(signals).toHaveLength(2);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+
+  it("clears the timeout when an attempt completes", async () => {
+    let completedSignal: AbortSignal | undefined;
+
+    const result = await attempt(
+      async (signal) => {
+        completedSignal = signal;
+        return "success";
+      },
+      { attemptCount: 1, delayMs: 0, timeoutMs: 5 }
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(result).toBe("success");
+    expect(completedSignal?.aborted).toBe(false);
+  });
+});


### PR DESCRIPTION
Fix #95 

- Added `timeoutMs` option to `attempt` function for request timeouts.
- Updated `attempt` to use `AbortController` for handling timeouts and retries.
- Enhanced `getDocument` and `fetchConfig` functions to accept `AbortSignal`.
- Updated relevant tests and modules to support the new timeout functionality.