### PR TITLE
Abstract `fetch` calls into `fetchLibgen` helper to enforce `User-Age…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,11 +5,16 @@
 /standalone-executables
 /media
 /legacy
+/test
 
 .gitignore
 /.vscode
 /.idea
 /.claude
+/.trekker
+
+eslint.config.js
+bun.lock
 
 *.chm
 *.pdf

--- a/src/api/data/config.ts
+++ b/src/api/data/config.ts
@@ -1,6 +1,7 @@
 import { CONFIGURATION_URL } from "../../settings";
 import { attempt } from "../../utilities";
 import type { AttemptOptions } from "../../utilities";
+import { fetchLibgen } from "./request";
 
 export type MirrorType = "libgen-plus";
 
@@ -35,7 +36,7 @@ export async function findMirror(
   attemptOptions?: AttemptOptions
 ): Promise<Mirror | undefined> {
   for (const mirror of mirrors) {
-    const response = await attempt((signal) => fetch(mirror.src, { signal }), attemptOptions);
+    const response = await attempt((signal) => fetchLibgen(mirror.src, signal), attemptOptions);
     if (response) {
       return mirror;
     }

--- a/src/api/data/document.ts
+++ b/src/api/data/document.ts
@@ -1,5 +1,5 @@
 import { parseHTML } from "linkedom";
-import { LIBGEN_USER_AGENT } from "../../settings";
+import { fetchLibgen } from "./request";
 
 export interface DocumentResult {
   document: Document;
@@ -8,12 +8,7 @@ export interface DocumentResult {
 
 export async function getDocument(searchURL: string, signal: AbortSignal): Promise<DocumentResult> {
   try {
-    const response = await fetch(searchURL, {
-      headers: {
-        "User-Agent": LIBGEN_USER_AGENT,
-      },
-      signal,
-    });
+    const response = await fetchLibgen(searchURL, signal);
     const htmlString = await response.text();
     const { document } = parseHTML(htmlString);
     return { document: document as unknown as Document, htmlString };

--- a/src/api/data/request.ts
+++ b/src/api/data/request.ts
@@ -1,0 +1,10 @@
+import { LIBGEN_USER_AGENT } from "../../settings";
+
+export function fetchLibgen(input: RequestInfo | URL, signal: AbortSignal): Promise<Response> {
+  return fetch(input, {
+    headers: {
+      "User-Agent": LIBGEN_USER_AGENT,
+    },
+    signal,
+  });
+}

--- a/src/tui/store/bulk-download-queue.ts
+++ b/src/tui/store/bulk-download-queue.ts
@@ -7,6 +7,7 @@ import { IDownloadProgress } from "./download-queue";
 import { getDocument } from "../../api/data/document";
 import { downloadFile } from "../../api/data/download";
 import { createMD5ListFile } from "../../api/data/file";
+import { fetchLibgen } from "../../api/data/request";
 import objectHash from "object-hash";
 
 export interface IBulkDownloadQueueItem extends IDownloadProgress {
@@ -210,7 +211,7 @@ export const createBulkDownloadQueueStateSlice = (
         continue;
       }
 
-      const downloadStream = await attempt((signal) => fetch(downloadUrl, { signal }));
+      const downloadStream = await attempt((signal) => fetchLibgen(downloadUrl, signal));
       if (!downloadStream) {
         get().setWarningMessage(`Couldn't fetch the download stream for ${item.md5}`);
         get().onBulkQueueItemFail(index);

--- a/src/tui/store/download-queue.ts
+++ b/src/tui/store/download-queue.ts
@@ -4,6 +4,7 @@ import { DownloadStatus } from "../../download-statuses";
 import { attempt } from "../../utilities";
 import { getDocument } from "../../api/data/document";
 import { downloadFile } from "../../api/data/download";
+import { fetchLibgen } from "../../api/data/request";
 
 export interface IDownloadProgress {
   filename: string;
@@ -142,7 +143,7 @@ export const createDownloadQueueStateSlice = (
         continue;
       }
 
-      const downloadStream = await attempt((signal) => fetch(downloadUrl as string, { signal }));
+      const downloadStream = await attempt((signal) => fetchLibgen(downloadUrl as string, signal));
       if (!downloadStream) {
         store.setWarningMessage(`Couldn't fetch the download stream for "${entry.title}"`);
         store.increaseTotalFailed();

--- a/test/data.test.ts
+++ b/test/data.test.ts
@@ -46,6 +46,14 @@ describe("configuration data", () => {
       findMirror(mirrors, onMirrorFail, { attemptCount: 1, delayMs: 0, timeoutMs: 100 })
     ).resolves.toEqual(mirrors[1]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "https://offline.example/", {
+      headers: { "User-Agent": LIBGEN_USER_AGENT },
+      signal: expect.any(AbortSignal),
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "https://online.example/", {
+      headers: { "User-Agent": LIBGEN_USER_AGENT },
+      signal: expect.any(AbortSignal),
+    });
     expect(onMirrorFail).toHaveBeenCalledWith("https://offline.example/");
   });
 });

--- a/test/queue.integration.test.ts
+++ b/test/queue.integration.test.ts
@@ -9,6 +9,7 @@ import { initialBulkDownloadQueueState } from "../src/tui/store/bulk-download-qu
 import { initialConfigState } from "../src/tui/store/config";
 import { initialDownloadQueueState } from "../src/tui/store/download-queue";
 import { useBoundStore } from "../src/tui/store";
+import { LIBGEN_USER_AGENT } from "../src/settings";
 
 const BASE_URL = "https://libgen.example/";
 const originalStoreState = useBoundStore.getState();
@@ -40,12 +41,16 @@ const createEntry = (id: string, md5: string): Entry => ({
 const installNetworkFixture = () => {
   const requestedURLs: string[] = [];
   const requestSignals: AbortSignal[] = [];
+  const requestHeaders: HeadersInit[] = [];
   const fixtureFetch = Object.assign(
     async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = getRequestURL(input);
       requestedURLs.push(url);
       if (init?.signal) {
         requestSignals.push(init.signal);
+      }
+      if (init?.headers) {
+        requestHeaders.push(init.headers);
       }
 
       if (url.includes("/ads.php?md5=success")) {
@@ -73,7 +78,7 @@ const installNetworkFixture = () => {
   );
   const fetchMock = spyOn(globalThis, "fetch").mockImplementation(fixtureFetch);
 
-  return { fetchMock, requestedURLs, requestSignals };
+  return { fetchMock, requestedURLs, requestSignals, requestHeaders };
 };
 
 const installFilesystemFixture = () => {
@@ -131,7 +136,7 @@ describe("download queue integration", () => {
   });
 
   it("resolves a mirror page, downloads the file, and completes the queue item", async () => {
-    const { fetchMock, requestedURLs, requestSignals } = installNetworkFixture();
+    const { fetchMock, requestedURLs, requestSignals, requestHeaders } = installNetworkFixture();
     const { createWriteStream, downloadedChunks } = installFilesystemFixture();
     const entry = createEntry("entry-1", "success");
     useBoundStore.setState({
@@ -149,6 +154,10 @@ describe("download queue integration", () => {
     ]);
     expect(requestSignals).toHaveLength(2);
     expect(requestSignals.every((signal) => !signal.aborted)).toBe(true);
+    expect(requestHeaders).toEqual([
+      { "User-Agent": LIBGEN_USER_AGENT },
+      { "User-Agent": LIBGEN_USER_AGENT },
+    ]);
     expect(createWriteStream).toHaveBeenCalledWith("./success.epub");
     expect(Buffer.concat(downloadedChunks).toString()).toBe("downloaded content");
     expect(state.downloadProgressMap[entry.id]).toMatchObject({
@@ -194,7 +203,7 @@ describe("bulk download integration", () => {
   });
 
   it("processes successful and failed items and records only completed MD5s", async () => {
-    const { fetchMock } = installNetworkFixture();
+    const { fetchMock, requestHeaders } = installNetworkFixture();
     const { downloadedChunks, writeFile } = installFilesystemFixture();
     useBoundStore.setState({
       bulkDownloadQueue: [
@@ -219,6 +228,11 @@ describe("bulk download integration", () => {
 
     const state = useBoundStore.getState();
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(requestHeaders).toEqual([
+      { "User-Agent": LIBGEN_USER_AGENT },
+      { "User-Agent": LIBGEN_USER_AGENT },
+      { "User-Agent": LIBGEN_USER_AGENT },
+    ]);
     expect(state.bulkDownloadQueue).toMatchObject([
       {
         md5: "success",

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -26,20 +26,33 @@ describe("attempt", () => {
     expect(signals[0]).not.toBe(signals[1]);
   });
 
-  it("clears the timeout when an attempt completes", async () => {
+  it("does not abort a response body after the fetch attempt completes", async () => {
     let completedSignal: AbortSignal | undefined;
 
-    const result = await attempt(
+    const response = await attempt(
       async (signal) => {
         completedSignal = signal;
-        return "success";
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            signal.addEventListener(
+              "abort",
+              () => controller.error(new Error("download was aborted")),
+              { once: true }
+            );
+
+            setTimeout(() => {
+              controller.enqueue(Buffer.from("downloaded content"));
+              controller.close();
+            }, 10);
+          },
+        });
+
+        return new Response(body);
       },
       { attemptCount: 1, delayMs: 0, timeoutMs: 5 }
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(result).toBe("success");
+    await expect(response?.text()).resolves.toBe("downloaded content");
     expect(completedSignal?.aborted).toBe(false);
   });
 });


### PR DESCRIPTION
…nt` header and update all relevant tests and modules accordingly.